### PR TITLE
Add more clarity to readme about an output file

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To generate the custom gource log and display it you need to tell the `gramps2go
 
 Example:
 
-    $ python gramps2gource.py --name="Amber Marie Smith" --db=example.gramps
+    $ python gramps2gource.py --name="Amber Marie Smith" --db=example.gramps --output=pedigree_amber_marie_smith.log
     $ cat pedigree_amber_marie_smith.log | gource --load-config gource.conf -
 
 The `gource.conf` effectively builds a command line similar to:
@@ -122,7 +122,7 @@ Multiple `name` arguments can be specified if you want to show more than one foc
 
 Example:
 
-    $ python gramps2gource.py --name="Amber Marie Smith" --name="John Hjalmar Smith" --db=example.gramps
+    $ python gramps2gource.py --name="Amber Marie Smith" --name="John Hjalmar Smith" --db=example.gramps --output=pedigree.log
     $ cat pedigree.log | gource --load-config gource.conf --hide-root -
 
 


### PR DESCRIPTION
As for me it's a little bit hard to understand for user why `cat` reads info from **this** file. Especially if user can't (*don't want to*) read the code.

So, I think it'll be better to show the full version of a command with the `--output` option.

**BTW**, maybe it'll be also a good solution to show to user some more details about the case when `--output` is omitted (how an output file's name is generated). Maybe somewhere there: https://github.com/claws/gramps2gource/blob/master/gramps2gource.py#L335